### PR TITLE
Fix flag functionality

### DIFF
--- a/app/assets/javascripts/flagged_projects.js
+++ b/app/assets/javascripts/flagged_projects.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/stylesheets/flagged_projects.scss
+++ b/app/assets/stylesheets/flagged_projects.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the flagged_projects controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/flagged_projects_controller.rb
+++ b/app/controllers/flagged_projects_controller.rb
@@ -1,0 +1,20 @@
+class FlaggedProjectsController < ApplicationController
+
+  def create
+    @flagged_project = FlaggedProject.create(project_id: params[:project_id], user_id: current_user.id)
+    redirect_to project_path(@flagged_project.project)
+  end
+
+  def show
+    @projects = Project.where(flagged: true)
+  end
+
+  def destroy
+    @project = Project.find_by(id: params[:project_id])
+    @flagged_project = FlaggedProject.find_by(project_id: params[:project_id])
+    @flagged_project.destroy
+    # binding.pry
+    redirect_to project_path(@project)
+
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -47,13 +47,7 @@ class ProjectsController < ApplicationController
   def show
   end
 
-  def flag
-     @project = Project.find_by(id: params[:project_id])
-     @project.update_attributes(flagged: true)
-     current_user.flagged_projects << @project
-     redirect_to projects_path
 
-  end
 
   private
 

--- a/app/helpers/flagged_projects_helper.rb
+++ b/app/helpers/flagged_projects_helper.rb
@@ -1,0 +1,2 @@
+module FlaggedProjectsHelper
+end

--- a/app/models/flagged_project.rb
+++ b/app/models/flagged_project.rb
@@ -1,0 +1,5 @@
+class FlaggedProject < ActiveRecord::Base
+
+  belongs_to :flagging_user, class_name: "User"
+  belongs_to :project
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -13,6 +13,10 @@ class Project < ActiveRecord::Base
     expiration.strftime("%D")
   end
 
+  def is_flagged
+    FlaggedProject.find_by(project_id: id)
+  end
+
   private
 
   def set_expiration
@@ -26,4 +30,6 @@ class Project < ActiveRecord::Base
       self.tagline = "Seeking collaborators"
     end
   end
+
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,10 +35,6 @@ class User < ActiveRecord::Base
     favorites.any?{|fave| fave.project_id == project.id}
   end
 
-  def has_flagged?(project)
-    flagged_projects.include?(project)
-  end
-
   def admin?
     role == "admin"
   end

--- a/app/views/projects/_index_show.html.erb
+++ b/app/views/projects/_index_show.html.erb
@@ -29,16 +29,7 @@
              </h4>
            </div>
          </div>
-         <div class="col-xs-2 col-md-2">
-       <div class="right">
-         <h4><% if (current_user.id == project.user_id && project.flagged) || current_user.has_flagged?(project)  %>
-             <%=link_to image_tag("flag-red.png"),projects_flag_path(project_id: project.id) %>
-             <% else %>
-             <%=link_to image_tag("flag-grey.png"),projects_flag_path(project_id: project.id) %>
-             <%end%>
-         </h4>
-       </div>
-     </div>
+
       </div>
    </div>
   </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -6,6 +6,7 @@
   <%if current_user && @project.user.id === current_user.id %>
     <%=link_to 'edit | ', edit_project_path(@project) %>
   <%end%>
+  <%= link_to 'back to projects', projects_path %>
 
 <div class="container panel-body"
 <div class="row">
@@ -32,6 +33,24 @@
               </h4>
 </div>
 </div>
+
+
+         <h4><% if current_user %>
+              <% if (current_user == @project.user) && @project.is_flagged %>
+              reported
+              <%elsif @project.is_flagged %>
+                <%if current_user.id == @project.is_flagged.user_id %>
+                 <%=link_to 'reported, click to remove flag', delete_flagged_project_path(project_id: @project.id) %>
+                <%else%>
+                   <%=link_to 'report', new_flagged_project_path(project_id: @project.id) %>
+                <%end%>
+               <% elsif current_user != @project.user %>
+
+               <%=link_to 'report', new_flagged_project_path(project_id: @project.id) %>
+               <%end%>
+               <%end%>
+         </h4>
+
 
 
   <div class="panel panel-default panel-body col-md-11">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,8 @@ Rails.application.routes.draw do
   get '/users/mail_conversations', to: 'conversations#inbox', as: 'inbox'
   get '/users/inbox_conversations/:id', to: 'conversations#inbox_messages_show', as: 'inbox_messages_show'
   post '/users/inbox_conversations/:id', to: 'messages#create', as: 'inbox_message'
-  get "projects/flag" => "projects#flag", :as => "projects/flag"
+
+
 
   resources :conversations do
     resources :messages
@@ -36,6 +37,10 @@ Rails.application.routes.draw do
   get 'favorite/delete', to: "favorites#destroy", as: "delete_favorite"
   get 'favorite', to: "favorites#show", as: "favorite"
   get 'favorites/new', to: "favorites#create", as: "new_favorite"
+
+  get 'flagged/new', to: "flagged_projects#create", as: "new_flagged_project"
+  get 'flagged', to: "flagged_projects#show", as: "flagged"
+  get 'flagged/delete', to: "flagged_projects#destroy", as: "delete_flagged_project"
 
   # admin
   get '/admin', to: "users#admin", as: "admin"

--- a/db/migrate/20160606144958_create_flagged_projects.rb
+++ b/db/migrate/20160606144958_create_flagged_projects.rb
@@ -1,0 +1,10 @@
+class CreateFlaggedProjects < ActiveRecord::Migration
+  def change
+    create_table :flagged_projects do |t|
+      t.references :user, foreign_key: true
+      t.references :project, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160604180745) do
+ActiveRecord::Schema.define(version: 20160606144958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,13 @@ ActiveRecord::Schema.define(version: 20160604180745) do
   add_index "conversations", ["sender_id"], name: "index_conversations_on_sender_id", using: :btree
 
   create_table "favorites", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "project_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "flagged_projects", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "project_id"
     t.datetime "created_at", null: false
@@ -110,6 +117,8 @@ ActiveRecord::Schema.define(version: 20160604180745) do
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
 
+  add_foreign_key "flagged_projects", "projects"
+  add_foreign_key "flagged_projects", "users"
   add_foreign_key "messages", "conversations"
   add_foreign_key "messages", "users"
   add_foreign_key "reviews", "users"

--- a/spec/controllers/flagged_projects_controller_spec.rb
+++ b/spec/controllers/flagged_projects_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe FlaggedProjectsController, type: :controller do
+
+end

--- a/spec/helpers/flagged_projects_helper_spec.rb
+++ b/spec/helpers/flagged_projects_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the FlaggedProjectsHelper. For example:
+#
+# describe FlaggedProjectsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe FlaggedProjectsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/flagged_project_spec.rb
+++ b/spec/models/flagged_project_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe FlaggedProject, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
@choff999 @mindplace @samanthavholmes 
Rename flags "report," and move to project show page-- fix logic so project owners cannot report their own projects, and cannot "unreport" their own projects; reported status only visible to user who reported that project. Users can unreport a project.